### PR TITLE
Change URL of FTP download server for newlib

### DIFF
--- a/toolchain/build-xenon-toolchain
+++ b/toolchain/build-xenon-toolchain
@@ -80,7 +80,7 @@ function toolchain_install
         # Check if newlib sources are available, download it if needed
         if [ ! -f "$NEWLIB.tar.gz" ]; then
                 echo -e "Downloading $NEWLIB.tar.gz"
-                wget -c ftp://sources.redhat.com/pub/newlib/$NEWLIB.tar.gz || exit 1
+                wget -c ftp://sourceware.org/pub/newlib/$NEWLIB.tar.gz || exit 1
         fi;
 
         rm -rf build


### PR DESCRIPTION
Use alternative mirror. Sources.redhat.org no longer allows anonymous FTP connections